### PR TITLE
Fix Jekyll CI vendor scan

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,7 +40,7 @@ plugins:
   - jekyll-sitemap  # Automatically generates sitemap.xml
 
 exclude:
-  - docs/superpowers/plans/
+  - vendor/
 
 # Collections - Portfolio and Blog
 collections:


### PR DESCRIPTION
## Summary
- Excludes vendor from Jekyll builds so GitHub Actions does not scan Bundler-installed gems.
- Removes the obsolete Codex plans exclude from site config.

## Root cause
GitHub Actions installs gems into vendor/bundle. Jekyll was scanning that directory and failing on Jekyll's internal site template post with an ERB date.

## Validation
- bundle exec jekyll build
- git diff --check
- tracked-file cleanup scan for Codex/plans/work artifacts