### PR TITLE
Fix Jekyll deploy pipeline

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,7 +40,7 @@ plugins:
   - jekyll-sitemap  # Automatically generates sitemap.xml
 
 exclude:
-  - docs/superpowers/plans/
+  - vendor/
 
 # Collections - Portfolio and Blog
 collections:


### PR DESCRIPTION
## Summary
- Excludes vendor from Jekyll builds so GitHub Actions does not scan Bundler-installed gems.
- Keeps Codex plan artifacts out of the tracked site configuration.

## Root cause
The main-branch deploy run installed gems into vendor/bundle. Jekyll then scanned that directory and failed on an internal Jekyll template post with an ERB date.

## Validation
- bundle exec jekyll build
- git diff --check
- tracked-file cleanup scan for Codex/plans/work artifacts